### PR TITLE
Allow module to be bundled with browserify and webpack. Fixes #9

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 node_modules
-src
 test
 tools
 docs

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 node_modules
+src
 test
 tools
 docs

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JSON-RPC 2.0 implementation over WebSockets for Node.js",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "mkdir -p ./dist && eslint --fix -c ./.eslintrc.json './src/**/*.js' './test/**/*.js' && babel ./src -d ./dist && browserify -s RPCWebSocket ./dist/lib/client.js > ./dist/index.browser.js",
+    "build": "mkdir -p ./dist && eslint --fix -c ./.eslintrc.json './src/**/*.js' './test/**/*.js' && babel ./src -d ./dist && browserify -s RPCWebSocket ./dist/index.browser.js > ./dist/index.browser-bundle.js",
     "pretest": "npm run-script build",
     "test": "mocha test/*spec.js",
     "coverage": "istanbul cover _mocha --report lcovonly -- -R spec",
@@ -37,9 +37,7 @@
     "mocha": "^3.0.2",
     "mocha-lcov-reporter": "^1.2.0"
   },
-  "browser": {
-    "./dist/lib/client/websocket.js": "./dist/lib/client/websocket.browser.js"
-  },
+  "browser": "./dist/index.browser.js",
   "keywords": [
     "json",
     "rpc",

--- a/src/index.browser.js
+++ b/src/index.browser.js
@@ -1,0 +1,6 @@
+"use strict"
+
+import WebSocket from "./lib/client/websocket.browser"
+import clientFactory from "./lib/client"
+
+export const Client = clientFactory(WebSocket)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 "use strict"
 
-export {default as Client} from "./lib/client"
+import WebSocket from "./lib/client/websocket"
+import clientFactory from "./lib/client"
+
+export const Client = clientFactory(WebSocket)
 export {default as Server} from "./lib/server"

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -8,10 +8,9 @@
 
 import assertArgs from "assert-args"
 import EventEmitter from "eventemitter3"
-import WebSocket from "./client/websocket"
 import CircularJSON from "circular-json"
 
-export default class Client extends EventEmitter
+export default (WebSocket) => class Client extends EventEmitter
 {
     /**
      * Instantiate a Client class.


### PR DESCRIPTION
With this change, you can now `require('rpc-websockets')` in your browser builds. This will be correctly resolved to the browser client only when using browserify or webpack.

There are a couple notable changes:

- The distributed browser build is now located at `dist/index.browser-bundle.js`.
- The API for the browser build matches the server-side build, where `Client` is exported from the main module, rather than the Client constructor being the default export.
- `src/lib/client.js` now exports a factory function to allow for a websocket dependency to be injected. This greatly simplified the isomorphic build process