### PR TITLE
Custom request id generation function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ db/
 docker/src/
 
 node_modules/
+.idea/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Parameters:
   * `reconnect` {Boolean}: Whether client should reconnect automatically once the connection is down. Defaults to `true`.
   * `reconnect_interval` {Number}: Time between adjacent reconnects. Defaults to `1000`.
   * `max_reconnects` {Number}: Maximum number of times the client should try to reconnect. Defaults to `5`.
+* `generate_request_id` {Function} Custom function to generate request id instead of simple increment by default. Passes `method` and `params` to parameters.
 
 ### ws.call(method[, params[, timeout[, μws_options]]]) -> Promise
 

--- a/dist/index.browser-bundle.js
+++ b/dist/index.browser-bundle.js
@@ -98,6 +98,7 @@ exports.default = function (WebSocket) {
          * @constructor
          * @param {String} address - url to a websocket server
          * @param {Object} options - ws options object with reconnect parameters
+         * @param {Function} generate_request_id - custom generation request Id
          * @return {Client}
          */
         function Client() {
@@ -113,6 +114,7 @@ exports.default = function (WebSocket) {
                 _ref$max_reconnects = _ref.max_reconnects,
                 max_reconnects = _ref$max_reconnects === undefined ? 5 : _ref$max_reconnects;
 
+            var generate_request_id = arguments[2];
             (0, _classCallCheck3.default)(this, Client);
 
             var _this = (0, _possibleConstructorReturn3.default)(this, (Client.__proto__ || (0, _getPrototypeOf2.default)(Client)).call(this));
@@ -126,6 +128,9 @@ exports.default = function (WebSocket) {
             _this.reconnect_interval = reconnect_interval;
             _this.max_reconnects = max_reconnects;
             _this.current_reconnects = 0;
+            _this.generate_request_id = generate_request_id || function () {
+                return ++_this.rpc_id;
+            };
 
             if (_this.autoconnect) _this._connect(address, arguments[1]);
             return _this;
@@ -162,7 +167,7 @@ exports.default = function (WebSocket) {
                 return new _promise2.default(function (resolve, reject) {
                     if (!_this2.ready) return reject(new Error("socket not ready"));
 
-                    var rpc_id = ++_this2.rpc_id;
+                    var rpc_id = _this2.generate_request_id(method, params);
 
                     var message = {
                         jsonrpc: "2.0",

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -77,6 +77,7 @@ exports.default = function (WebSocket) {
          * @constructor
          * @param {String} address - url to a websocket server
          * @param {Object} options - ws options object with reconnect parameters
+         * @param {Function} generate_request_id - custom generation request Id
          * @return {Client}
          */
         function Client() {
@@ -92,6 +93,7 @@ exports.default = function (WebSocket) {
                 _ref$max_reconnects = _ref.max_reconnects,
                 max_reconnects = _ref$max_reconnects === undefined ? 5 : _ref$max_reconnects;
 
+            var generate_request_id = arguments[2];
             (0, _classCallCheck3.default)(this, Client);
 
             var _this = (0, _possibleConstructorReturn3.default)(this, (Client.__proto__ || (0, _getPrototypeOf2.default)(Client)).call(this));
@@ -105,6 +107,9 @@ exports.default = function (WebSocket) {
             _this.reconnect_interval = reconnect_interval;
             _this.max_reconnects = max_reconnects;
             _this.current_reconnects = 0;
+            _this.generate_request_id = generate_request_id || function () {
+                return ++_this.rpc_id;
+            };
 
             if (_this.autoconnect) _this._connect(address, arguments[1]);
             return _this;
@@ -141,7 +146,7 @@ exports.default = function (WebSocket) {
                 return new _promise2.default(function (resolve, reject) {
                     if (!_this2.ready) return reject(new Error("socket not ready"));
 
-                    var rpc_id = ++_this2.rpc_id;
+                    var rpc_id = _this2.generate_request_id(method, params);
 
                     var message = {
                         jsonrpc: "2.0",

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -17,6 +17,7 @@ export default (WebSocket) => class Client extends EventEmitter
      * @constructor
      * @param {String} address - url to a websocket server
      * @param {Object} options - ws options object with reconnect parameters
+     * @param {Function} generate_request_id - custom generation request Id
      * @return {Client}
      */
     constructor(address = "ws://localhost:8080", {
@@ -24,7 +25,9 @@ export default (WebSocket) => class Client extends EventEmitter
         reconnect = true,
         reconnect_interval = 1000,
         max_reconnects = 5
-    } = {})
+    } = {},
+    generate_request_id
+    )
     {
         super()
 
@@ -37,6 +40,7 @@ export default (WebSocket) => class Client extends EventEmitter
         this.reconnect_interval = reconnect_interval
         this.max_reconnects = max_reconnects
         this.current_reconnects = 0
+        this.generate_request_id = generate_request_id || (() => ++this.rpc_id)
 
         if (this.autoconnect)
             this._connect(address, arguments[1])
@@ -71,7 +75,7 @@ export default (WebSocket) => class Client extends EventEmitter
             if (!this.ready)
                 return reject(new Error("socket not ready"))
 
-            const rpc_id = ++this.rpc_id
+            const rpc_id = this.generate_request_id(method, params)
 
             const message = {
                 jsonrpc: "2.0",


### PR DESCRIPTION
Add custom request-id generation function as parameter of client.
This is useful for logging and debugging requests at server, for example.