### PR TITLE
Remove socket at any position from events array on close

### DIFF
--- a/dist/lib/server.js
+++ b/dist/lib/server.js
@@ -148,7 +148,7 @@ var Server = function (_EventEmitter) {
 
                         var index = _this.namespaces[ns].events[event].indexOf(socket._id);
 
-                        if (index === 0) _this.namespaces[ns].events[event].splice(index, 1);
+                        if (index >= 0) _this.namespaces[ns].events[event].splice(index, 1);
                     }
                 } catch (err) {
                     _didIteratorError = true;

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -59,7 +59,7 @@ export default class Server extends EventEmitter
                 {
                     const index = this.namespaces[ns].events[event].indexOf(socket._id)
 
-                    if (index === 0)
+                    if (index >= 0)
                         this.namespaces[ns].events[event].splice(index, 1)
                 }
             })


### PR DESCRIPTION
This fixes an issue where clients subscribed to events are not removed when the connection is closed and one or more clients are still connected.