### PR TITLE
Accounting for empty options argument

### DIFF
--- a/src/lib/client/websocket.browser.js
+++ b/src/lib/client/websocket.browser.js
@@ -38,6 +38,8 @@ export default class WebSocket extends EventEmitter
      */
     send(data, options, callback)
     {
+        callback = callback || options;
+        
         try
         {
             this.socket.send(data)


### PR DESCRIPTION
Ran into this while building with webpack.  `notify` will call send with only `data` and `callback` which will throw as `callback` is undefined without options provided.